### PR TITLE
make connector extendable

### DIFF
--- a/connector-it/src/test/resources/application.yml
+++ b/connector-it/src/test/resources/application.yml
@@ -18,6 +18,7 @@ spring:
       pubsub:
         emulator-host: localhost:38085
         project-id: integration-test
+        enabled: true
 
 redis:
   host: localhost

--- a/connector-server/src/main/java/org/interledger/connector/server/spring/gcp/GcpPubSubConfig.java
+++ b/connector-server/src/main/java/org/interledger/connector/server/spring/gcp/GcpPubSubConfig.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 import javax.annotation.PostConstruct;
 
 @Configuration
-@ConditionalOnProperty("spring.cloud.gcp.pubsub.project-id")
+@ConditionalOnProperty(value = "spring.cloud.gcp.pubsub.enabled", havingValue = "true")
 public class GcpPubSubConfig {
 
   @Autowired

--- a/connector-server/src/main/java/org/interledger/connector/server/spring/settings/SpringConnectorConfig.java
+++ b/connector-server/src/main/java/org/interledger/connector/server/spring/settings/SpringConnectorConfig.java
@@ -105,7 +105,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;
@@ -138,6 +140,10 @@ import java.util.function.Supplier;
   SpringConnectorWebMvc.class,
   GcpPubSubConfig.class
 })
+@ComponentScan(basePackages = "${interledger.connector.extensions.basePackage:org.interledger.connector.extensions}",
+  useDefaultFilters = false,
+  includeFilters = @ComponentScan.Filter(type= FilterType.REGEX, pattern=".*")
+)
 public class SpringConnectorConfig {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());

--- a/connector-server/src/main/java/org/interledger/connector/server/spring/settings/SpringConnectorConfig.java
+++ b/connector-server/src/main/java/org/interledger/connector/server/spring/settings/SpringConnectorConfig.java
@@ -112,6 +112,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.util.List;
@@ -140,9 +141,10 @@ import java.util.function.Supplier;
   SpringConnectorWebMvc.class,
   GcpPubSubConfig.class
 })
+// support extension by looking for annotated Component/Config classes under the configured extensions.basePackage
 @ComponentScan(basePackages = "${interledger.connector.extensions.basePackage:org.interledger.connector.extensions}",
   useDefaultFilters = false,
-  includeFilters = @ComponentScan.Filter(type= FilterType.REGEX, pattern=".*")
+  includeFilters = @ComponentScan.Filter(type= FilterType.ANNOTATION, value = Component.class)
 )
 public class SpringConnectorConfig {
 

--- a/connector-server/src/main/resources/application.yml
+++ b/connector-server/src/main/resources/application.yml
@@ -28,6 +28,8 @@ server:
   jetty:
     max-form-post-size: 32767 # Max per ILP ASN.1
 spring:
+  profiles:
+    include: extensions
   cache:
     redis:
       time-to-live: 86400


### PR DESCRIPTION
Make it possible the connector to be extended in a project with custom beans
Enable limited Spring component scanning in a specific package as configured by `interledger.connector.extensions.basePackage`. Only `@Component` beans will be included in the autoscan.
To make it easy for the extending project to specify default Spring properties (such as the extensions.basePackage), include an "extensions" profile.
also realized the way we are conditionally enabling GcpPubSubConfig should use the enabled flag already defined

example project showing a connector that provides a different implementation of GcpPacketResponseEventPublisher: https://github.com/interledger4j/example-ilpv4-connector-extended

address #578 