### PR TITLE
gracefully handle and log a peer that cannot be registered for ccp

### DIFF
--- a/connector-routing-impl/src/main/java/org/interledger/connector/routing/InMemoryExternalRoutingService.java
+++ b/connector-routing-impl/src/main/java/org/interledger/connector/routing/InMemoryExternalRoutingService.java
@@ -236,7 +236,13 @@ public class InMemoryExternalRoutingService implements ExternalRoutingService {
         .addAll(accountSettingsRepository.findByAccountRelationshipIsWithConversion(AccountRelationship.PARENT))
       .build();
 
-    peersAndParent.stream().forEach(routeBroadcaster::registerCcpEnabledAccount);
+    peersAndParent.stream().forEach(account -> {
+      try {
+        routeBroadcaster.registerCcpEnabledAccount(account);
+      } catch (Exception e) {
+        logger.warn("CCP registration failed for account id: " + account.accountId(), e);
+      }
+    });
 
     //////////////////
     // Child Accounts

--- a/connector-routing-impl/src/test/java/org/interledger/connector/routing/InMemoryExternalRoutingServiceTest.java
+++ b/connector-routing-impl/src/test/java/org/interledger/connector/routing/InMemoryExternalRoutingServiceTest.java
@@ -194,6 +194,38 @@ public class InMemoryExternalRoutingServiceTest {
     verify(routeBroadcaster, times(0)).registerCcpEnabledAccount(child);
   }
 
+  @Test
+  public void misconfiguredAccountsAreGracefullyHandled() {
+
+    LinkType ilpoverhttp = LinkType.of("ILPOVERHTTP");
+    AccountSettings goodPeer = AccountSettings.builder()
+      .assetCode("XRP")
+      .assetScale(9)
+      .linkType(ilpoverhttp)
+      .accountId(AccountId.of("good_peer"))
+      .accountRelationship(AccountRelationship.PEER)
+      .build();
+
+    AccountSettings badPeer = AccountSettings.builder()
+      .assetCode("XRP")
+      .assetScale(9)
+      .linkType(ilpoverhttp)
+      .accountId(AccountId.of("bad_peer"))
+      .accountRelationship(AccountRelationship.PEER)
+      .build();
+
+
+    when(accountSettingsRepository.findByAccountRelationshipIsWithConversion(AccountRelationship.PEER))
+      .thenReturn(Lists.newArrayList(badPeer, goodPeer));
+
+    when(routeBroadcaster.registerCcpEnabledAccount(badPeer)).thenThrow(new RuntimeException("fake exception!"));
+    when(routeBroadcaster.registerCcpEnabledAccount(goodPeer)).thenReturn(Optional.empty());
+
+    service.start();
+    verify(routeBroadcaster, times(1)).registerCcpEnabledAccount(badPeer);
+    verify(routeBroadcaster, times(1)).registerCcpEnabledAccount(goodPeer);
+  }
+
 
   private Set<StaticRoute> defaultRoutes() {
     return Sets.newHashSet(shawn, lassiter);


### PR DESCRIPTION
previously the connector would die and became hard to fix the issue if it required update the peer's settings

address #557 