### PR TITLE
fix docker image that's broken due to missing spsp-core jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ jobs:
           MAVEN_OPTS: -Xmx4096m
 
     steps:
+      - setup_remote_docker
       - checkout
       - restore_cache:
           keys:
@@ -194,6 +195,7 @@ workflows:
   commit:
     jobs:
       - build
+      - docker_image # FIXME remove this. just for testing it works
       - integration_tests_ilp_over_http:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
             - v1-dependencies-{{ checksum "pom.xml" }}
       - run:
           name: Deploy docker image
-          command: mvn clean install -DskipTests -Pdocker -Dcontainer.version=nightly
+          command: mvn verify -DskipTests -Pdocker -Dcontainer.version=nightly
 
 workflows:
   version: 2
@@ -196,7 +196,6 @@ workflows:
   commit:
     jobs:
       - build
-      - docker_image # FIXME remove this. just for testing it works
       - integration_tests_ilp_over_http:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
             - v1-dependencies-{{ checksum "pom.xml" }}
       - run:
           name: Deploy docker image
-          command: mvn package -DskipTests -DskipITs -Pdocker -Dcontainer.version=nightly -Djib.to.auth.username=${DOCKERHUB_USERNAME} -Djib.to.auth.password=${DOCKERHUB_API_KEY}
+          command: mvn clean install -DskipTests -Pdocker -Dcontainer.version=nightly
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,14 +170,15 @@ jobs:
 
   docker_image:
     working_directory: ~/repo
-    docker:
-      - image: circleci/openjdk:8-jdk
-        environment:
-          # Customize the JVM maximum heap limit
-          MAVEN_OPTS: -Xmx4096m
+
+    machine:
+      image: ubuntu-1604:201903-01
+
+    environment:
+      MAVEN_OPTS: -Xmx4096m
+      JAVA_HOME: /usr/lib/jvm/jdk1.8.0/
 
     steps:
-      - setup_remote_docker
       - checkout
       - restore_cache:
           keys:

--- a/connector-it/pom.xml
+++ b/connector-it/pom.xml
@@ -119,6 +119,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
@@ -163,6 +169,11 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.interledger.connector</groupId>
+      <artifactId>connector-admin-client</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -284,6 +295,7 @@
                 org.interledger.connector.it.markers.Settlement
               </groups>
               <excludedGroups>
+                org.interledger.connector.it.markers.DockerImage,
                 org.interledger.connector.it.markers.IlpOverHttp,
                 org.interledger.connector.it.markers.Performance
               </excludedGroups>
@@ -322,6 +334,46 @@
                 org.interledger.connector.it.markers.IlpOverHttp
               </groups>
               <excludedGroups>
+                org.interledger.connector.it.markers.DockerImage,
+                org.interledger.connector.it.markers.Settlement,
+                org.interledger.connector.it.markers.Performance
+              </excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <!-- Actually runs Integration Tests (use -DskipITs to skip) -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>run-integration-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <skipTests>false</skipTests>
+              <skipITs>false</skipITs>
+              <useSystemClassLoader>false</useSystemClassLoader>
+              <encoding>UTF-8</encoding>
+              <!-- see: https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class -->
+              <argLine>${failsafe.argLine} -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+              <useSystemClassLoader>false</useSystemClassLoader>
+              <groups>
+                org.interledger.connector.it.markers.DockerImage
+              </groups>
+              <excludedGroups>
+                org.interledger.connector.it.markers.IlpOverHttp,
                 org.interledger.connector.it.markers.Settlement,
                 org.interledger.connector.it.markers.Performance
               </excludedGroups>

--- a/connector-it/src/main/java/org/interledger/connector/it/markers/DockerImage.java
+++ b/connector-it/src/main/java/org/interledger/connector/it/markers/DockerImage.java
@@ -1,0 +1,8 @@
+package org.interledger.connector.it.markers;
+
+/**
+ * A marker interface used by JUnit to indicate this test applies to java connector docker image validation
+ */
+public interface DockerImage {
+  /* category marker */
+}

--- a/connector-it/src/test/java/org/interledger/connector/it/ContainerHelper.java
+++ b/connector-it/src/test/java/org/interledger/connector/it/ContainerHelper.java
@@ -8,6 +8,8 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.util.Optional;
+
 public final class ContainerHelper {
 
   public static GenericContainer redis(Network network) {
@@ -57,6 +59,14 @@ public final class ContainerHelper {
     if (logger != null) {
       container = container.withLogConsumer(new org.testcontainers.containers.output.Slf4jLogConsumer (logger));
     }
+    return container;
+  }
+
+  public static GenericContainer javaConnector(String version, Optional<Logger> logger) {
+    GenericContainer container = new GenericContainer("interledger4j/java-ilpv4-connector:" + version)
+      .withExposedPorts(8080)
+      .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Started ServerConnector.*$"));
+    logger.ifPresent($ -> container.withLogConsumer(new org.testcontainers.containers.output.Slf4jLogConsumer($)));
     return container;
   }
 }

--- a/connector-it/src/test/java/org/interledger/connector/it/docker/JavaConnectorDockerImageIT.java
+++ b/connector-it/src/test/java/org/interledger/connector/it/docker/JavaConnectorDockerImageIT.java
@@ -1,0 +1,66 @@
+package org.interledger.connector.it.docker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.interledger.connector.accounts.sub.LocalDestinationAddressUtils.PING_ACCOUNT_ID;
+
+import org.interledger.connector.client.ConnectorAdminClient;
+import org.interledger.connector.it.ContainerHelper;
+import org.interledger.connector.it.markers.DockerImage;
+
+import okhttp3.HttpUrl;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.Optional;
+
+/**
+ * Test to validate the docker container can start up with the default dev profile
+ */
+@Category(DockerImage.class)
+public class JavaConnectorDockerImageIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JavaConnectorDockerImageIT.class);
+  private static final String containerVersion = Optional.ofNullable(System.getProperty("container.version"))
+    .orElse("nightly");
+
+  private static GenericContainer connector =
+    ContainerHelper.javaConnector(containerVersion, Optional.of(LOGGER));
+  private ConnectorAdminClient connectorAdminClient;
+
+  @BeforeClass
+  public static void startTopology() {
+    connector.start();
+  }
+
+  @AfterClass
+  public static void stopTopology() {
+    connector.stop();
+  }
+
+  @Before
+  public void setUp() {
+    connectorAdminClient = ConnectorAdminClient.construct(getConnectorBaseUrl(), template -> {
+      template.header("Authorization", "Basic YWRtaW46cGFzc3dvcmQ=");
+    });
+  }
+
+  private HttpUrl getConnectorBaseUrl() {
+    return new HttpUrl.Builder()
+      .scheme("http")
+      .host(connector.getContainerIpAddress())
+      .port(connector.getFirstMappedPort())
+      .build();
+  }
+
+  @Test
+  public void basicAPI()  {
+    assertThat(connectorAdminClient.findAccount(PING_ACCOUNT_ID.value())).isPresent();
+  }
+
+}

--- a/connector-server/pom.xml
+++ b/connector-server/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.interledger.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>0.2.0</version>
   </parent>
 
   <artifactId>connector-server</artifactId>
@@ -18,6 +18,9 @@
   <properties>
     <container.image>interledger4j/java-ilpv4-connector</container.image>
     <container.version>${project.version}</container.version>
+    <!-- by default, configure jib plugin goal to build the docker image locally but not publish to dockerhub -->
+    <!-- to release and push to dockerhub run: mvn clean package -Pdocker,dockerhub -->
+    <jibGoal>dockerBuild</jibGoal>
   </properties>
 
   <build>
@@ -256,7 +259,7 @@
     <dependency>
       <groupId>org.interledger</groupId>
       <artifactId>spsp-core</artifactId>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.interledger</groupId>
@@ -410,24 +413,30 @@
 
   <profiles>
     <profile>
+      <id>dockerhub</id>
+      <properties>
+        <!-- override jib plugin goal to "build" which builds image and pushes to dockerhub -->
+        <jibGoal>build</jibGoal>
+      </properties>
+    </profile>
+    <profile>
       <!-- this profile builds 2 docker images, 1 with newrelic agent and 1 without any agent configured -->
       <id>docker</id>
-      <!-- ship liquibase with docker image build -->
-      <dependencies>
-        <dependency>
-          <groupId>com.newrelic.agent.java</groupId>
-          <artifactId>newrelic-java</artifactId>
-          <version>5.9.0</version>
-          <scope>provided</scope>
-          <type>zip</type>
-        </dependency>
-      </dependencies>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <version>3.1.1</version>
+            <dependencies>
+              <dependency>
+                <groupId>com.newrelic.agent.java</groupId>
+                <artifactId>newrelic-java</artifactId>
+                <version>5.9.0</version>
+                <scope>runtime</scope>
+                <type>zip</type>
+              </dependency>
+            </dependencies>
             <executions>
               <execution>
                 <id>unpack-newrelic</id>
@@ -457,7 +466,7 @@
                 <!-- pinning to prepare-package so that it runs before the 2 new relic-specific plugin exections -->
                 <phase>prepare-package</phase>
                 <goals>
-                  <goal>build</goal>
+                  <goal>${jibGoal}</goal>
                 </goals>
                 <configuration>
                   <to>
@@ -481,7 +490,7 @@
                 <id>dockerNewRelic</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>build</goal>
+                  <goal>${jibGoal}</goal>
                 </goals>
                 <configuration>
                   <to>

--- a/connector-server/pom.xml
+++ b/connector-server/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.interledger.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>0.2.0</version>
+    <version>HEAD-SNAPSHOT</version>
   </parent>
 
   <artifactId>connector-server</artifactId>


### PR DESCRIPTION
spsp-core needs to be on the server's classpath if local spsp feature is enabled. This was not happening because the dependency was marked as "test"
create IT to verify the Java connector docker container can start up
modify circle builds to only build the docker image but not push it to dockerhub
due to limitations with circleci permissions we don't want to expose the dockerhub credentials to anyone with access to circle builds
