### PR TITLE
bug fixes for local spsp fulfillment:

### DIFF
--- a/connector-model/src/main/java/org/interledger/connector/settings/SpspSettings.java
+++ b/connector-model/src/main/java/org/interledger/connector/settings/SpspSettings.java
@@ -31,6 +31,6 @@ public interface SpspSettings {
    *
    * @return An optionally-present String.
    */
-  Optional<String> urlPathPrefix();
+  Optional<String> urlPath();
 
 }

--- a/connector-server/src/main/java/org/interledger/connector/server/wallet/controllers/SpspController.java
+++ b/connector-server/src/main/java/org/interledger/connector/server/wallet/controllers/SpspController.java
@@ -30,7 +30,6 @@ import org.zalando.problem.spring.common.MediaTypes;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -82,6 +81,7 @@ public class SpspController {
     }
 
     final InterledgerAddress paymentReceiverAddress = connectorSettingsSupplier.get().operatorAddress()
+      .with(connectorSettingsSupplier.get().spspSettings().addressPrefixSegment())
       .with(ilpIntermediateSuffix);
 
     final StreamConnectionDetails streamConnectionDetails = streamReceiver.setupStream(paymentReceiverAddress);

--- a/connector-server/src/test/java/org/interledger/connector/server/wallet/controllers/SpspControllerWithNoPathSpringTest.java
+++ b/connector-server/src/test/java/org/interledger/connector/server/wallet/controllers/SpspControllerWithNoPathSpringTest.java
@@ -135,13 +135,14 @@ public class SpspControllerWithNoPathSpringTest extends AbstractEndpointTest {
   @Test
   public void bobPaysAliceUsingLocalFulfillment() throws InterruptedException, ExecutionException, TimeoutException {
     String authToken = "shh";
-    AccountSettings bob = createAccount(AccountId.of(BOB), customSettingsSimple(authToken));
-    createAccount(AccountId.of(ALICE), customSettingsSimple(authToken));
-    final IlpOverHttpLink ilpOverHttpLink = linkToServer(AccountId.of(BOB), authToken, okHttpClient, objectMapper);
+    AccountSettings bob = createAccount(AccountId.of(BOB + UUID.randomUUID()), customSettingsSimple(authToken));
+    AccountSettings alice =
+      createAccount(AccountId.of(ALICE + UUID.randomUUID()), customSettingsSimple(authToken));
+    final IlpOverHttpLink ilpOverHttpLink = linkToServer(bob.accountId(), authToken, okHttpClient, objectMapper);
 
     final StreamConnectionDetails connectionDetails = spspClient.getStreamConnectionDetails(
       HttpUrl.parse("http://localhost:" + randomServerPort).newBuilder()
-        .addPathSegment(ALICE)
+        .addPathSegment(alice.accountId().value())
         .build()
     );
 

--- a/connector-server/src/test/java/org/interledger/connector/server/wallet/controllers/SpspControllerWithNoPathSpringTest.java
+++ b/connector-server/src/test/java/org/interledger/connector/server/wallet/controllers/SpspControllerWithNoPathSpringTest.java
@@ -2,23 +2,44 @@ package org.interledger.connector.server.wallet.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.startsWith;
+import static org.interledger.connector.server.spring.settings.link.IlpOverHttpConfig.ILP_OVER_HTTP;
 
+import org.interledger.connector.accounts.AccountId;
+import org.interledger.connector.accounts.AccountSettings;
 import org.interledger.connector.server.ConnectorServerConfig;
+import org.interledger.connector.server.ilpoverhttp.AbstractEndpointTest;
+import org.interledger.core.InterledgerAddress;
+import org.interledger.link.http.IlpOverHttpLink;
 import org.interledger.spsp.StreamConnectionDetails;
 import org.interledger.spsp.client.SimpleSpspClient;
 import org.interledger.spsp.client.SpspClient;
 import org.interledger.spsp.client.SpspClientException;
+import org.interledger.stream.Denomination;
+import org.interledger.stream.SendMoneyRequest;
+import org.interledger.stream.SendMoneyResult;
+import org.interledger.stream.sender.FixedSenderAmountPaymentTracker;
+import org.interledger.stream.sender.SimpleStreamSender;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
 import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Unit test that excercises the SPSP Controller when SPSP is configured to run with an empty spsp path (e.g., for
@@ -31,13 +52,20 @@ import org.springframework.test.context.junit4.SpringRunner;
   properties = {"interledger.connector.spsp.urlPath="}
 )
 @ActiveProfiles( {"test"}) // Uses the `application-test.properties` file in the `src/test/resources` folder
-public class SpspControllerWithNoPathSpringTest {
+public class SpspControllerWithNoPathSpringTest extends AbstractEndpointTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
   @LocalServerPort
   private int randomServerPort;
+
+  @Autowired
+  @Qualifier(ILP_OVER_HTTP)
+  private OkHttpClient okHttpClient;
+
+  @Autowired
+  private ObjectMapper objectMapper;
 
   private SpspClient spspClient;
 
@@ -98,6 +126,41 @@ public class SpspControllerWithNoPathSpringTest {
 
     assertThat(result.destinationAddress().startsWith("test1.connie.accounts"));
     assertThat(result.sharedSecret()).isNotNull();
+  }
+
+  /**
+   * Validate that Bob can send a packet to `alice` and get a fulfillment back. Since local spsp fulfillment is enabled,
+   * this should succeed.
+   */
+  @Test
+  public void bobPaysAliceUsingLocalFulfillment() throws InterruptedException, ExecutionException, TimeoutException {
+    String authToken = "shh";
+    AccountSettings bob = createAccount(AccountId.of(BOB), customSettingsSimple(authToken));
+    createAccount(AccountId.of(ALICE), customSettingsSimple(authToken));
+    final IlpOverHttpLink ilpOverHttpLink = linkToServer(AccountId.of(BOB), authToken, okHttpClient, objectMapper);
+
+    final StreamConnectionDetails connectionDetails = spspClient.getStreamConnectionDetails(
+      HttpUrl.parse("http://localhost:" + randomServerPort).newBuilder()
+        .addPathSegment(ALICE)
+        .build()
+    );
+
+    SimpleStreamSender simpleStreamSender = new SimpleStreamSender(ilpOverHttpLink);
+
+    UnsignedLong amountToSend = UnsignedLong.valueOf(1000);
+    SendMoneyResult sendResult = simpleStreamSender.sendMoney(
+      SendMoneyRequest.builder()
+        .sharedSecret(connectionDetails.sharedSecret())
+        .destinationAddress(connectionDetails.destinationAddress())
+        .sourceAddress(InterledgerAddress.of("test.foo"))
+        .amount(amountToSend)
+        .paymentTracker(new FixedSenderAmountPaymentTracker(amountToSend))
+        .denomination(Denomination.builder().assetCode(bob.assetCode()).assetScale((short) bob.assetScale()).build())
+        .requestId(UUID.randomUUID())
+        .build()
+    ).get(10, TimeUnit.SECONDS);
+
+    assertThat(sendResult.successfulPayment()).isTrue();
   }
 
 }

--- a/connector-server/src/test/resources/application-test.yml
+++ b/connector-server/src/test/resources/application-test.yml
@@ -16,6 +16,7 @@ interledger:
       localSpspFulfillmentEnabled: true
     spsp:
         urlPath: p
+        addressPrefixSegment: spsp-test
     globalRoutingSettings:
       # A simulated routing secret, which is a seed used for generating routing table auth values.
       # Represents the plaintext value of `shh`, encrypted.

--- a/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/ConnectorSettingsFromPropertyFile.java
+++ b/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/ConnectorSettingsFromPropertyFile.java
@@ -56,6 +56,8 @@ public class ConnectorSettingsFromPropertyFile implements ConnectorSettings {
 
   private ConnectorKeysFromPropertyFile keys;
 
+  private SpspSettingsFromPropertyFile spsp = new SpspSettingsFromPropertyFile();
+
   @Override
   public InterledgerAddress operatorAddress() {
     return nodeIlpAddress;
@@ -169,6 +171,19 @@ public class ConnectorSettingsFromPropertyFile implements ConnectorSettings {
 
   public void setKeys(ConnectorKeysFromPropertyFile keys) {
     this.keys = keys;
+  }
+
+  public SpspSettingsFromPropertyFile spsp() {
+    return spspSettings();
+  }
+
+  @Override
+  public SpspSettingsFromPropertyFile spspSettings() {
+    return spsp;
+  }
+
+  public void setSpsp(SpspSettingsFromPropertyFile spsp) {
+    this.spsp = spsp;
   }
 
   /**

--- a/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/EnabledFeatureSettingsFromPropertyFile.java
+++ b/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/EnabledFeatureSettingsFromPropertyFile.java
@@ -9,6 +9,7 @@ public class EnabledFeatureSettingsFromPropertyFile implements EnabledFeatureSet
 
   private boolean rateLimitingEnabled;
   private boolean require32ByteSharedSecrets;
+  private boolean localSpspFulfillmentEnabled;
 
   @Override
   public boolean isRateLimitingEnabled() {
@@ -27,4 +28,14 @@ public class EnabledFeatureSettingsFromPropertyFile implements EnabledFeatureSet
   public void setRequire32ByteSharedSecrets(boolean require32ByteSharedSecrets) {
     this.require32ByteSharedSecrets = require32ByteSharedSecrets;
   }
+
+  @Override
+  public boolean isLocalSpspFulfillmentEnabled() {
+    return localSpspFulfillmentEnabled;
+  }
+
+  public void setLocalSpspFulfillmentEnabled(boolean localSpspFulfillmentEnabled) {
+    this.localSpspFulfillmentEnabled = localSpspFulfillmentEnabled;
+  }
+
 }

--- a/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/EnabledProtocolSettingsFromPropertyFile.java
+++ b/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/EnabledProtocolSettingsFromPropertyFile.java
@@ -10,6 +10,7 @@ public class EnabledProtocolSettingsFromPropertyFile implements EnabledProtocolS
   private boolean pingProtocolEnabled;
   private boolean peerRoutingEnabled;
   private boolean ildcpEnabled;
+  private boolean spspEnabled;
 
   @Override
   public boolean isPingProtocolEnabled() {
@@ -37,4 +38,14 @@ public class EnabledProtocolSettingsFromPropertyFile implements EnabledProtocolS
   public void setIldcpEnabled(boolean ildcpEnabled) {
     this.ildcpEnabled = ildcpEnabled;
   }
+
+  @Override
+  public boolean isSpspEnabled() {
+    return spspEnabled;
+  }
+
+  public void setSpspEnabled(boolean spspEnabled) {
+    this.spspEnabled = spspEnabled;
+  }
+
 }

--- a/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/SpspSettingsFromPropertyFile.java
+++ b/connector-service-impl/src/main/java/org/interledger/connector/settings/properties/SpspSettingsFromPropertyFile.java
@@ -1,0 +1,31 @@
+package org.interledger.connector.settings.properties;
+
+import org.interledger.connector.settings.SpspSettings;
+
+import java.util.Optional;
+
+public class SpspSettingsFromPropertyFile implements SpspSettings {
+
+  private String addressPrefixSegment;
+
+  private String urlPath;
+
+  @Override
+  public String addressPrefixSegment() {
+    return addressPrefixSegment;
+  }
+
+  public void setAddressPrefixSegment(String addressPrefixSegment) {
+    this.addressPrefixSegment = addressPrefixSegment;
+  }
+
+  @Override
+  public Optional<String> urlPath() {
+    return Optional.ofNullable(urlPath);
+  }
+
+  public void setUrlPath(String urlPath) {
+    this.urlPath = urlPath;
+  }
+
+}

--- a/connector-service-impl/src/test/java/org/interledger/connector/settings/properties/ConnectorSettingsFromPropertyFileTest.java
+++ b/connector-service-impl/src/test/java/org/interledger/connector/settings/properties/ConnectorSettingsFromPropertyFileTest.java
@@ -49,12 +49,12 @@ public class ConnectorSettingsFromPropertyFileTest {
     assertThat(enabledProtocolSettings.isPeerRoutingEnabled()).isTrue();
     assertThat(enabledProtocolSettings.isPingProtocolEnabled()).isTrue();
     assertThat(enabledProtocolSettings.isIldcpEnabled()).isTrue();
-    assertThat(enabledProtocolSettings.isSpspEnabled()).isFalse();
+    assertThat(enabledProtocolSettings.isSpspEnabled()).isTrue();
 
     // Enabled Features
     final EnabledFeatureSettings enabledFeatureSettings = connectorSettings.enabledFeatures();
     assertThat(enabledFeatureSettings.isRateLimitingEnabled()).isTrue();
-    assertThat(enabledFeatureSettings.isLocalSpspFulfillmentEnabled()).isFalse();
+    assertThat(enabledFeatureSettings.isLocalSpspFulfillmentEnabled()).isTrue();
     assertThat(enabledFeatureSettings.isRequire32ByteSharedSecrets()).isTrue();
 
     // Global Routing Settings
@@ -89,6 +89,9 @@ public class ConnectorSettingsFromPropertyFileTest {
       .isEqualTo(CryptoKey.builder().alias("secret0").version("2").build());
     assertThat(connectorSettings.keys().accountSettings())
       .isEqualTo(CryptoKey.builder().alias("accounts").version("3").build());
+
+    assertThat(connectorSettings.spspSettings().addressPrefixSegment()).isEqualTo("test-address-prefix");
+    assertThat(connectorSettings.spspSettings().urlPath()).isEqualTo(Optional.of("test-url-path"));
   }
 
   @EnableConfigurationProperties(ConnectorSettingsFromPropertyFile.class)

--- a/connector-service-impl/src/test/resources/application-connector-unit-test.yml
+++ b/connector-service-impl/src/test/resources/application-connector-unit-test.yml
@@ -47,12 +47,14 @@ interledger:
     enabledFeatures:
       rateLimitingEnabled: true
       require32ByteSharedSecrets: true
+      localSpspFulfillmentEnabled: true
     # Which protocols this Connector supports
     enabledProtocols:
       ilpOverHttpEnabled: true
       pingProtocolEnabled: true
       peerRoutingEnabled: true
       ildcpEnabled: true
+      spspEnabled: true
     # Global Routing Settings for this connector.
     globalRoutingSettings:
       # Whether to broadcast known routes.
@@ -73,3 +75,6 @@ interledger:
       routeExpiry: 30003
       # The maximum number of epochs per routing table update.
       maxEpochsPerRoutingTable: 77
+    spsp:
+      urlPath: test-url-path
+      addressPrefixSegment: test-address-prefix


### PR DESCRIPTION
- append the spsp prefix to the generated destination address for spsp requests
- fix property file configs to include spsp settings and localSpspFulfillmentEnabled flag
- fix naming mismatch between config files and java for spsp.urlPath

add integration test to exercise SPSP + Stream payment.