### PR TITLE
Durable payment receipt - Part 1: The Persistencing

### DIFF
--- a/connector-model/src/main/java/org/interledger/connector/transactions/Transaction.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/Transaction.java
@@ -1,0 +1,43 @@
+package org.interledger.connector.transactions;
+
+import org.interledger.connector.accounts.AccountId;
+import org.interledger.core.InterledgerAddress;
+
+import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Value.Immutable
+public interface Transaction {
+
+  static ImmutableTransaction.Builder builder() {
+    return ImmutableTransaction.builder();
+  }
+
+  String referenceId();
+
+  AccountId accountId();
+
+  Optional<InterledgerAddress> sourceAddress();
+
+  InterledgerAddress destinationAddress();
+
+  UnsignedLong amount();
+
+  int packetCount();
+
+  String assetCode();
+
+  short assetScale();
+
+  TransactionStatus status();
+
+  TransactionType type();
+
+  Instant createdAt();
+
+  Instant modifiedAt();
+
+}

--- a/connector-model/src/main/java/org/interledger/connector/transactions/Transaction.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/Transaction.java
@@ -23,7 +23,7 @@ public interface Transaction {
    * Reference Id for transaction. Locally unique by accountId.
    * @return
    */
-  String referenceId();
+  String transactionId();
 
   /**
    * AccountId that this transaction is attached to.

--- a/connector-model/src/main/java/org/interledger/connector/transactions/Transaction.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/Transaction.java
@@ -9,6 +9,9 @@ import org.immutables.value.Value;
 import java.time.Instant;
 import java.util.Optional;
 
+/**
+ *
+ */
 @Value.Immutable
 public interface Transaction {
 
@@ -16,20 +19,54 @@ public interface Transaction {
     return ImmutableTransaction.builder();
   }
 
+  /**
+   * Reference Id for transaction. Locally unique by accountId.
+   * @return
+   */
   String referenceId();
 
+  /**
+   * AccountId that this transaction is attached to.
+   * @return
+   */
   AccountId accountId();
 
+  /**
+   * Source address that initiated the payment. Optional because in the case of payments received, the source address
+   * will not be known if/until the sender sends a ConnectionNewAddress frame (which is not guaranteed).
+   * @return
+   */
   Optional<InterledgerAddress> sourceAddress();
 
+  /**
+   * Destination address where the payment was sent.
+   * @return
+   */
   InterledgerAddress destinationAddress();
 
+  /**
+   * Amount (in assetScale) of the accountId's account settings at the time the transaction was created.
+   * @return
+   */
   UnsignedLong amount();
 
+  /**
+   * Number of ILP packets that were aggregated into this transaction.
+   * @return
+   */
   int packetCount();
 
+  /**
+   * Asset code of the accountId's account settings at the time the transaction was created.
+   * @return
+   */
   String assetCode();
 
+
+  /**
+   * Asset scale of the accountId's account settings at the time the transaction was created.
+   * @return
+   */
   short assetScale();
 
   TransactionStatus status();

--- a/connector-model/src/main/java/org/interledger/connector/transactions/TransactionStatus.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/TransactionStatus.java
@@ -1,0 +1,10 @@
+package org.interledger.connector.transactions;
+
+public enum TransactionStatus {
+
+  UNKNOWN, // when transaction status from an unchec
+  PENDING,
+  CLOSED_BY_EXPIRATION, // indicates transaction was closed as a result of max transaction time expiration
+  CLOSED_BY_STREAM; // indicates transaction was closed as a result of sender sending a StreamClose frame
+
+}

--- a/connector-model/src/main/java/org/interledger/connector/transactions/TransactionStatus.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/TransactionStatus.java
@@ -5,7 +5,6 @@ package org.interledger.connector.transactions;
  */
 public enum TransactionStatus {
 
-  UNKNOWN, // when transaction status from the database can't be mapped
   PENDING, // for transactions with packets in flight that haven't closed yet
   CLOSED_BY_EXPIRATION, // indicates transaction was closed as a result of max transaction time expiration
   CLOSED_BY_STREAM; // indicates transaction was closed as a result of sender sending a StreamClose frame

--- a/connector-model/src/main/java/org/interledger/connector/transactions/TransactionStatus.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/TransactionStatus.java
@@ -1,9 +1,12 @@
 package org.interledger.connector.transactions;
 
+/**
+ * Status of a {@link Transaction}.
+ */
 public enum TransactionStatus {
 
-  UNKNOWN, // when transaction status from an unchec
-  PENDING,
+  UNKNOWN, // when transaction status from the database can't be mapped
+  PENDING, // for transactions with packets in flight that haven't closed yet
   CLOSED_BY_EXPIRATION, // indicates transaction was closed as a result of max transaction time expiration
   CLOSED_BY_STREAM; // indicates transaction was closed as a result of sender sending a StreamClose frame
 

--- a/connector-model/src/main/java/org/interledger/connector/transactions/TransactionType.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/TransactionType.java
@@ -6,10 +6,7 @@ package org.interledger.connector.transactions;
 public enum TransactionType {
 
   PAYMENT_RECEIVED(BalanceAdjustmentType.CREDIT),
-  PAYMENT_SENT(BalanceAdjustmentType.DEBIT),
-  // for raw status strings from the database that don't map to any of the above. Shouldn't happen but just in case
-  // map to this rather than null
-  UNKNOWN(null);
+  PAYMENT_SENT(BalanceAdjustmentType.DEBIT);
 
   private BalanceAdjustmentType adjustmentType;
 

--- a/connector-model/src/main/java/org/interledger/connector/transactions/TransactionType.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/TransactionType.java
@@ -1,9 +1,14 @@
 package org.interledger.connector.transactions;
 
+/**
+ * Types of {@link Transaction} that the system tracks.
+ */
 public enum TransactionType {
 
   PAYMENT_RECEIVED(BalanceAdjustmentType.CREDIT),
   PAYMENT_SENT(BalanceAdjustmentType.DEBIT),
+  // for raw status strings from the database that don't map to any of the above. Shouldn't happen but just in case
+  // map to this rather than null
   UNKNOWN(null);
 
   private BalanceAdjustmentType adjustmentType;

--- a/connector-model/src/main/java/org/interledger/connector/transactions/TransactionType.java
+++ b/connector-model/src/main/java/org/interledger/connector/transactions/TransactionType.java
@@ -1,0 +1,27 @@
+package org.interledger.connector.transactions;
+
+public enum TransactionType {
+
+  PAYMENT_RECEIVED(BalanceAdjustmentType.CREDIT),
+  PAYMENT_SENT(BalanceAdjustmentType.DEBIT),
+  UNKNOWN(null);
+
+  private BalanceAdjustmentType adjustmentType;
+
+  TransactionType(BalanceAdjustmentType adjustmentType) {
+    this.adjustmentType = adjustmentType;
+  }
+
+  public BalanceAdjustmentType getAdjustmentType() {
+    return adjustmentType;
+  }
+
+  /**
+   * Types of changes that a transaction can make to a balance
+   */
+  enum BalanceAdjustmentType {
+    DEBIT,
+    CREDIT
+  }
+
+}

--- a/connector-persistence/pom.xml
+++ b/connector-persistence/pom.xml
@@ -201,7 +201,10 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.interledger.connector</groupId>
+      <artifactId>connector-model</artifactId>
     </dependency>
   </dependencies>
 

--- a/connector-persistence/pom.xml
+++ b/connector-persistence/pom.xml
@@ -206,6 +206,10 @@
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.interledger.connector</groupId>
+      <artifactId>connector-model</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/connector-persistence/pom.xml
+++ b/connector-persistence/pom.xml
@@ -177,6 +177,10 @@
       <artifactId>spring-tx</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.zonky.test</groupId>
       <artifactId>embedded-database-spring-test</artifactId>
       <version>1.5.2</version>
@@ -201,10 +205,6 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.interledger.connector</groupId>
-      <artifactId>connector-model</artifactId>
     </dependency>
   </dependencies>
 

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/config/EncryptedDatasourcePasswordConfig.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/config/EncryptedDatasourcePasswordConfig.java
@@ -3,6 +3,7 @@ package org.interledger.connector.persistence.config;
 import org.interledger.crypto.EncryptedSecret;
 import org.interledger.crypto.EncryptionService;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
@@ -31,6 +32,7 @@ public class EncryptedDatasourcePasswordConfig {
   protected DataSourceBuilder createDataSourceBuilder(DataSourceProperties dataSourceProperties,
                                                       EncryptionService encryptionService) {
     DataSourceBuilder dataSourceBuilder = DataSourceBuilder.create();
+    dataSourceBuilder.type(HikariDataSource.class);
     dataSourceBuilder.url(dataSourceProperties.determineUrl());
     dataSourceBuilder.username(dataSourceProperties.getUsername());
     if (dataSourceProperties.getPassword() != null && dataSourceProperties.getPassword().startsWith("enc")) {

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/DataConstants.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/DataConstants.java
@@ -8,6 +8,7 @@ public interface DataConstants {
     String DELETED_ACCOUNT_SETTINGS = "DELETED_ACCOUNT_SETTINGS";
     String FX_RATE_OVERRIDES = "FX_RATE_OVERRIDES";
     String STATIC_ROUTES = "STATIC_ROUTES";
+    String TRANSACTIONS = "TRANSACTIONS";
   }
 
   interface ColumnNames {

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/TransactionEntity.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/TransactionEntity.java
@@ -14,6 +14,10 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+/**
+ * Entity for persisting a transaction. See {@link org.interledger.connector.transactions.Transaction} for
+ * javadoc of each field's meaning.
+ */
 @Entity
 @Access(AccessType.FIELD)
 @Table(name = TRANSACTIONS)

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/TransactionEntity.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/TransactionEntity.java
@@ -3,6 +3,8 @@ package org.interledger.connector.persistence.entities;
 import static org.interledger.connector.persistence.entities.DataConstants.TableNames.TRANSACTIONS;
 
 import org.interledger.connector.accounts.AccountId;
+import org.interledger.connector.transactions.TransactionStatus;
+import org.interledger.connector.transactions.TransactionType;
 
 import java.math.BigInteger;
 import java.time.Instant;
@@ -11,6 +13,8 @@ import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
@@ -28,8 +32,8 @@ public class TransactionEntity {
   @Column(name = "ID")
   private Long id;
 
-  @Column(name = "REFERENCE_ID")
-  private String referenceId;
+  @Column(name = "TRANSACTION_ID")
+  private String transactionId;
 
   @Column(name = "ACCOUNT_ID")
   private AccountId accountId;
@@ -53,10 +57,12 @@ public class TransactionEntity {
   private String sourceAddress;
 
   @Column(name = "STATUS")
-  private String status;
+  @Enumerated(EnumType.STRING)
+  private TransactionStatus status;
 
   @Column(name = "TYPE")
-  private String type;
+  @Enumerated(EnumType.STRING)
+  private TransactionType type;
 
   @Column(name = "CREATED_DTTM", nullable = false, updatable = false)
   private Instant createdDate;
@@ -116,12 +122,12 @@ public class TransactionEntity {
   }
 
 
-  public String getReferenceId() {
-    return referenceId;
+  public String getTransactionId() {
+    return transactionId;
   }
 
-  public void setReferenceId(String referenceId) {
-    this.referenceId = referenceId;
+  public void setTransactionId(String transactionId) {
+    this.transactionId = transactionId;
   }
 
   public String getSourceAddress() {
@@ -132,19 +138,19 @@ public class TransactionEntity {
     this.sourceAddress = sourceAddress;
   }
 
-  public String getStatus() {
+  public TransactionStatus getStatus() {
     return status;
   }
 
-  public void setStatus(String status) {
+  public void setStatus(TransactionStatus status) {
     this.status = status;
   }
 
-  public String getType() {
+  public TransactionType getType() {
     return type;
   }
 
-  public void setType(String type) {
+  public void setType(TransactionType type) {
     this.type = type;
   }
 
@@ -171,7 +177,7 @@ public class TransactionEntity {
     }
 
     TransactionEntity that = (TransactionEntity) o;
-    return Objects.equals(getReferenceId(), that.getReferenceId());
+    return Objects.equals(getTransactionId(), that.getTransactionId());
   }
 
   /**
@@ -182,14 +188,14 @@ public class TransactionEntity {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(getReferenceId());
+    return Objects.hash(getTransactionId());
   }
 
   @Override
   public String toString() {
     return "TransactionEntity{" +
       "id=" + id +
-      ", referenceId='" + referenceId + '\'' +
+      ", transactionId='" + transactionId + '\'' +
       ", accountId=" + accountId +
       ", destinationAddress='" + destinationAddress + '\'' +
       ", assetCode='" + assetCode + '\'' +

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/TransactionEntity.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/TransactionEntity.java
@@ -1,0 +1,204 @@
+package org.interledger.connector.persistence.entities;
+
+import static org.interledger.connector.persistence.entities.DataConstants.TableNames.TRANSACTIONS;
+
+import org.interledger.connector.accounts.AccountId;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Objects;
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Access(AccessType.FIELD)
+@Table(name = TRANSACTIONS)
+@SuppressWarnings( {"PMD"})
+public class TransactionEntity {
+
+  @Id
+  @Column(name = "ID")
+  private Long id;
+
+  @Column(name = "REFERENCE_ID")
+  private String referenceId;
+
+  @Column(name = "ACCOUNT_ID")
+  private AccountId accountId;
+
+  @Column(name = "DESTINATION_ADDRESS")
+  private String destinationAddress;
+
+  @Column(name = "ASSET_CODE")
+  private String assetCode;
+
+  @Column(name = "ASSET_SCALE")
+  private short assetScale;
+
+  @Column(name = "AMOUNT")
+  private BigInteger amount;
+
+  @Column(name = "PACKET_COUNT")
+  private int packetCount;
+
+  @Column(name = "SOURCE_ADDRESS")
+  private String sourceAddress;
+
+  @Column(name = "STATUS")
+  private String status;
+
+  @Column(name = "TYPE")
+  private String type;
+
+  @Column(name = "CREATED_DTTM", nullable = false, updatable = false)
+  private Instant createdDate;
+
+  @Column(name = "MODIFIED_DTTM", nullable = false)
+  private Instant modifiedDate;
+
+  public Long getId() {
+    return id;
+  }
+
+  public AccountId getAccountId() {
+    return accountId;
+  }
+
+  public void setAccountId(AccountId accountId) {
+    this.accountId = accountId;
+  }
+
+  public String getDestinationAddress() {
+    return destinationAddress;
+  }
+
+  public void setDestinationAddress(String destinationAddress) {
+    this.destinationAddress = destinationAddress;
+  }
+  public String getAssetCode() {
+    return assetCode;
+  }
+
+  public void setAssetCode(String assetCode) {
+    this.assetCode = assetCode;
+  }
+
+  public short getAssetScale() {
+    return assetScale;
+  }
+
+  public void setAssetScale(short assetScale) {
+    this.assetScale = assetScale;
+  }
+
+  public BigInteger getAmount() {
+    return amount;
+  }
+
+  public void setAmount(BigInteger amount) {
+    this.amount = amount;
+  }
+
+  public int getPacketCount() {
+    return packetCount;
+  }
+
+  public void setPacketCount(int packetCount) {
+    this.packetCount = packetCount;
+  }
+
+
+  public String getReferenceId() {
+    return referenceId;
+  }
+
+  public void setReferenceId(String referenceId) {
+    this.referenceId = referenceId;
+  }
+
+  public String getSourceAddress() {
+    return sourceAddress;
+  }
+
+  public void setSourceAddress(String sourceAddress) {
+    this.sourceAddress = sourceAddress;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public Instant getCreatedDate() {
+    return createdDate;
+  }
+
+  public Instant getModifiedDate() {
+    return modifiedDate;
+  }
+
+  /**
+   * Overridden to use natural identifier.
+   *
+   * @see "https://vladmihalcea.com/the-best-way-to-implement-equals-hashcode-and-tostring-with-jpa-and-hibernate/"
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TransactionEntity that = (TransactionEntity) o;
+    return Objects.equals(getReferenceId(), that.getReferenceId());
+  }
+
+  /**
+   * Return the hashcode of the natural identifier.
+   *
+   * @return An integer representing the natural identifier for this entity.
+   * @see "https://vladmihalcea.com/the-best-way-to-implement-equals-hashcode-and-tostring-with-jpa-and-hibernate/"
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(getReferenceId());
+  }
+
+  @Override
+  public String toString() {
+    return "TransactionEntity{" +
+      "id=" + id +
+      ", referenceId='" + referenceId + '\'' +
+      ", accountId=" + accountId +
+      ", destinationAddress='" + destinationAddress + '\'' +
+      ", assetCode='" + assetCode + '\'' +
+      ", assetScale=" + assetScale +
+      ", amount=" + amount +
+      ", packetCount=" + packetCount +
+      ", sourceAddress='" + sourceAddress + '\'' +
+      ", status='" + status + '\'' +
+      ", type='" + type + '\'' +
+      ", createdDate=" + createdDate +
+      ", modifiedDate=" + modifiedDate +
+      '}';
+  }
+}
+
+

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepository.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepository.java
@@ -29,12 +29,12 @@ public interface TransactionsRepository extends Repository<TransactionEntity, Lo
 
   /**
    * Find an {@link TransactionEntity} by its natural identifier corresponding to
-   * {@link AccountId} and {@link TransactionEntity#getReferenceId()}.
+   * {@link AccountId} and {@link TransactionEntity#getTransactionId()}.
    *
    * @param accountId
-   * @param referenceId
+   * @param transactionId
    * @return record if found
    */
-  Optional<TransactionEntity> findByAccountIdAndReferenceId(AccountId accountId, String referenceId);
+  Optional<TransactionEntity> findByAccountIdAndTransactionId(AccountId accountId, String transactionId);
 
 }

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepository.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepository.java
@@ -1,0 +1,40 @@
+package org.interledger.connector.persistence.repositories;
+
+import org.interledger.connector.accounts.AccountId;
+import org.interledger.connector.persistence.entities.TransactionEntity;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read-only repository to fetch TransactionEntity from the database. For write operations,
+ * use {@link TransactionsRepositoryCustom} instead.
+ */
+@org.springframework.stereotype.Repository
+public interface TransactionsRepository extends Repository<TransactionEntity, Long>, TransactionsRepositoryCustom {
+
+  /**
+   * Find an list {@link TransactionEntity} by accountId order by creation date desc
+   *
+   * @param accountId An id corresponding to {@link TransactionEntity#getAccountId()}.
+   * @param pageable page request
+   *
+   * @return List of {@link TransactionEntity}.
+   */
+  List<TransactionEntity> findByAccountIdOrderByCreatedDateDesc(AccountId accountId, Pageable pageable);
+
+
+  /**
+   * Find an {@link TransactionEntity} by its natural identifier corresponding to
+   * {@link TransactionEntity#getReferenceId()}.
+   *
+   * @param accountId
+   * @param referenceId
+   * @return record if found
+   */
+  Optional<TransactionEntity> findByAccountIdAndReferenceId(AccountId accountId, String referenceId);
+
+}

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepository.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepository.java
@@ -29,7 +29,7 @@ public interface TransactionsRepository extends Repository<TransactionEntity, Lo
 
   /**
    * Find an {@link TransactionEntity} by its natural identifier corresponding to
-   * {@link TransactionEntity#getReferenceId()}.
+   * {@link AccountId} and {@link TransactionEntity#getReferenceId()}.
    *
    * @param accountId
    * @param referenceId

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustom.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustom.java
@@ -2,6 +2,7 @@ package org.interledger.connector.persistence.repositories;
 
 import org.interledger.connector.accounts.AccountId;
 import org.interledger.connector.persistence.entities.TransactionEntity;
+import org.interledger.connector.transactions.TransactionStatus;
 
 /**
  * Custom persistence operations for {@link TransactionEntity} that, for performance, are done
@@ -21,11 +22,11 @@ public interface TransactionsRepositoryCustom {
    * upsertAmounts does not update the status because status changes require an explicit event such
    * as a stream close frame being sent, or a transaction being rolled off based on time expiry.
    * @param accountId
-   * @param referenceId
+   * @param transactionId
    * @param status
    * @return number of rows updated. 1 = success.
    */
-  int updateStatus(AccountId accountId, String referenceId, String status);
+  int updateStatus(AccountId accountId, String transactionId, TransactionStatus status);
 
 
   /**
@@ -33,10 +34,10 @@ public interface TransactionsRepositoryCustom {
    * source address will not be present on most packets, just when the ILP stream data contains a ConnectionNewAddress
    * frame.
    * @param accountId
-   * @param referenceId
+   * @param transactionId
    * @param sourceAddress
    * @return number of rows updated. 1 = success
    */
-  int updateSourceAddress(AccountId accountId, String referenceId, String sourceAddress);
+  int updateSourceAddress(AccountId accountId, String transactionId, String sourceAddress);
 
 }

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustom.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustom.java
@@ -1,0 +1,33 @@
+package org.interledger.connector.persistence.repositories;
+
+import org.interledger.connector.accounts.AccountId;
+import org.interledger.connector.persistence.entities.TransactionEntity;
+
+/**
+ * Custom persistence operations for {@link TransactionEntity} that, for performance, are done
+ * via JDBC statements instead of using {@link TransactionsRepository}.
+ */
+public interface TransactionsRepositoryCustom {
+
+  /**
+   * Inserts or updates an transaction entity.
+   * @param transaction
+   * @return number of rows updated. 1 = success.
+   */
+  int upsertAmounts(TransactionEntity transaction);
+
+  /**
+   * Updates just the status column of the transactions table. This is done explicitly because
+   * upsertAmounts does not update the status because status changes require an explicit event such
+   * as a stream close frame being sent, or a transaction being rolled off based on time expiry.
+   * @param accountId
+   * @param referenceId
+   * @param status
+   * @return number of rows updated. 1 = success.
+   */
+  int updateStatus(AccountId accountId, String referenceId, String status);
+
+
+  int updateSourceAddress(AccountId accountId, String referenceId, String sourceAddress);
+
+}

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustom.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustom.java
@@ -10,7 +10,7 @@ import org.interledger.connector.persistence.entities.TransactionEntity;
 public interface TransactionsRepositoryCustom {
 
   /**
-   * Inserts or updates an transaction entity.
+   * Inserts or updates an transaction entity and merges amounts.
    * @param transaction
    * @return number of rows updated. 1 = success.
    */
@@ -28,6 +28,15 @@ public interface TransactionsRepositoryCustom {
   int updateStatus(AccountId accountId, String referenceId, String status);
 
 
+  /**
+   * Updates just the source_address column of the transactions table. This is done explicitly because
+   * source address will not be present on most packets, just when the ILP stream data contains a ConnectionNewAddress
+   * frame.
+   * @param accountId
+   * @param referenceId
+   * @param sourceAddress
+   * @return number of rows updated. 1 = success
+   */
   int updateSourceAddress(AccountId accountId, String referenceId, String sourceAddress);
 
 }

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustomImpl.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryCustomImpl.java
@@ -1,0 +1,78 @@
+package org.interledger.connector.persistence.repositories;
+
+import org.interledger.connector.accounts.AccountId;
+import org.interledger.connector.persistence.entities.TransactionEntity;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.persistence.EntityManager;
+
+public class TransactionsRepositoryCustomImpl implements TransactionsRepositoryCustom {
+
+  private static final String UPSERT = "INSERT INTO transactions " +
+    "(account_id, amount, asset_code, asset_scale, destination_address, packet_count, reference_id, source_address, " +
+    "status, type) values " +
+    "(:accountId, :amount, :assetCode, :assetScale, :destinationAddress, :packetCount, :referenceId, :sourceAddress, " +
+    ":status, :type) " +
+    "ON CONFLICT(account_id, reference_id) DO " +
+    "UPDATE SET amount=transactions.amount + excluded.amount, " +
+    "  modified_dttm=now(), " +
+    "  packet_count=transactions.packet_count+excluded.packet_count";
+
+  private static final String UPDATE_STATUS = "UPDATE transactions SET status = :status, modified_dttm=now() " +
+      "WHERE account_id = :accountId AND reference_id = :referenceId";
+
+  private static final String UPDATE_SOURCE_ADDRESS =
+    "UPDATE transactions SET source_address = :sourceAddress, modified_dttm=now() " +
+    "WHERE account_id = :accountId AND reference_id = :referenceId";
+
+  @Autowired
+  private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired
+  private EntityManager entityManager;
+
+  @Override
+  public int upsertAmounts(TransactionEntity transaction) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("accountId", transaction.getAccountId().value());
+    parameters.put("amount", transaction.getAmount());
+    parameters.put("assetCode", transaction.getAssetCode());
+    parameters.put("assetScale", transaction.getAssetScale());
+    parameters.put("destinationAddress", transaction.getDestinationAddress());
+    parameters.put("packetCount", transaction.getPacketCount());
+    parameters.put("referenceId", transaction.getReferenceId());
+    parameters.put("sourceAddress", transaction.getSourceAddress());
+    parameters.put("status", transaction.getStatus());
+    parameters.put("type", transaction.getType());
+
+    entityManager.clear();
+    return jdbcTemplate.update(UPSERT, parameters);
+  }
+
+  @Override
+  public int updateStatus(AccountId accountId, String referenceId, String status) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("accountId", accountId.value());
+    parameters.put("referenceId", referenceId);
+    parameters.put("status", status);
+
+    entityManager.clear();
+    return jdbcTemplate.update(UPDATE_STATUS, parameters);
+  }
+
+  @Override
+  public int updateSourceAddress(AccountId accountId, String referenceId, String sourceAddress) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("accountId", accountId.value());
+    parameters.put("referenceId", referenceId);
+    parameters.put("sourceAddress", sourceAddress);
+
+    entityManager.clear();
+    return jdbcTemplate.update(UPDATE_SOURCE_ADDRESS, parameters);
+  }
+
+}

--- a/connector-persistence/src/main/resources/db/changelog-master.xml
+++ b/connector-persistence/src/main/resources/db/changelog-master.xml
@@ -15,7 +15,6 @@
     <property name="timestamp" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
 
     <!-- DDL -->
-    <include file="db/changelogs/base/changelog.xml"/>
-    <include file="db/changelogs/base/changelog_00001_access_token.xml"/>
+    <includeAll path="db/changelogs/base"/>
 
 </databaseChangeLog>

--- a/connector-persistence/src/main/resources/db/changelogs/base/changelog_00002_transactions.xml
+++ b/connector-persistence/src/main/resources/db/changelogs/base/changelog_00002_transactions.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="transactions" author="nhartner">
+    <createTable tableName="TRANSACTIONS">
+      <column autoIncrement="true" name="ID" type="BIGINT">
+        <constraints nullable="false" primaryKey="true"/>
+      </column>
+      <column name="REFERENCE_ID" type="VARCHAR(64)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="ACCOUNT_ID" type="VARCHAR(64)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TYPE" type="VARCHAR(32)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="STATUS" type="VARCHAR(32)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="AMOUNT" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="ASSET_CODE" type="VARCHAR(20)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="ASSET_SCALE" type="SMALLINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="PACKET_COUNT" type="INTEGER">
+        <constraints nullable="false"/>
+      </column>
+      <column name="SOURCE_ADDRESS" type="VARCHAR(1024)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="DESTINATION_ADDRESS" type="VARCHAR(1024)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="CREATED_DTTM" type="DATETIME" defaultValue="now()">
+        <constraints nullable="false"/>
+      </column>
+      <column name="MODIFIED_DTTM" type="DATETIME" defaultValue="now()">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <createIndex indexName="TRANSACTIONS_ACCT_ID_CREATED_IDX"
+                 tableName="TRANSACTIONS">
+      <column name="ACCOUNT_ID"/>
+      <column name="CREATED_DTTM"/>
+    </createIndex>
+    <createIndex indexName="TRANSACTIONS_ACCT_ID_REF_ID_IDX"
+                 tableName="TRANSACTIONS"
+                 unique="true">
+      <column name="ACCOUNT_ID"/>
+      <column name="REFERENCE_ID"/>
+    </createIndex>
+    <createIndex indexName="TRANSACTIONS_STATUS_CREATED_DTTM_IDX"
+                 tableName="TRANSACTIONS">
+      <column name="STATUS"/>
+      <column name="CREATED_DTTM"/>
+    </createIndex>
+
+  </changeSet>
+</databaseChangeLog>

--- a/connector-persistence/src/main/resources/db/changelogs/base/changelog_00002_transactions.xml
+++ b/connector-persistence/src/main/resources/db/changelogs/base/changelog_00002_transactions.xml
@@ -9,7 +9,7 @@
       <column autoIncrement="true" name="ID" type="BIGINT">
         <constraints nullable="false" primaryKey="true"/>
       </column>
-      <column name="REFERENCE_ID" type="VARCHAR(64)">
+      <column name="TRANSACTION_ID" type="VARCHAR(64)">
         <constraints nullable="false"/>
       </column>
       <column name="ACCOUNT_ID" type="VARCHAR(64)">
@@ -51,11 +51,11 @@
       <column name="ACCOUNT_ID"/>
       <column name="CREATED_DTTM"/>
     </createIndex>
-    <createIndex indexName="TRANSACTIONS_ACCT_ID_REF_ID_IDX"
+    <createIndex indexName="TRANSACTIONS_ACCT_ID_TRX_ID_IDX"
                  tableName="TRANSACTIONS"
                  unique="true">
       <column name="ACCOUNT_ID"/>
-      <column name="REFERENCE_ID"/>
+      <column name="TRANSACTION_ID"/>
     </createIndex>
     <createIndex indexName="TRANSACTIONS_STATUS_CREATED_DTTM_IDX"
                  tableName="TRANSACTIONS">

--- a/connector-persistence/src/test/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryTest.java
+++ b/connector-persistence/src/test/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.interledger.connector.accounts.AccountId;
 import org.interledger.connector.persistence.config.ConnectorPersistenceConfig;
-import org.interledger.connector.persistence.converters.AccessTokenEntityConverter;
 import org.interledger.connector.persistence.entities.TransactionEntity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -212,13 +211,6 @@ public class TransactionsRepositoryTest {
   @Configuration("application.yml")
   public static class TestPersistenceConfig {
 
-    ////////////////////////
-    // SpringConverters
-    ////////////////////////
-
-    @Autowired
-    private AccessTokenEntityConverter accessTokensEntityConverter;
-
     @Bean
     public ObjectMapper objectMapper() {
       return new ObjectMapper();
@@ -226,9 +218,7 @@ public class TransactionsRepositoryTest {
 
     @Bean
     public ConfigurableConversionService conversionService() {
-      ConfigurableConversionService conversionService = new DefaultConversionService();
-      conversionService.addConverter(accessTokensEntityConverter);
-      return conversionService;
+      return new DefaultConversionService();
     }
   }
 }

--- a/connector-persistence/src/test/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryTest.java
+++ b/connector-persistence/src/test/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryTest.java
@@ -148,8 +148,6 @@ public class TransactionsRepositoryTest {
 
     assertEqual(loadedAccessTokenEntity, entity1);
 
-    Thread.sleep(1000); // sleep to make it more predictable to
-
     final TransactionEntity entity2 = newEntity(accountId, transactionId, 20);
     transactionsRepository.upsertAmounts(entity2);
 

--- a/connector-persistence/src/test/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryTest.java
+++ b/connector-persistence/src/test/java/org/interledger/connector/persistence/repositories/TransactionsRepositoryTest.java
@@ -1,0 +1,234 @@
+package org.interledger.connector.persistence.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.interledger.connector.accounts.AccountId;
+import org.interledger.connector.persistence.config.ConnectorPersistenceConfig;
+import org.interledger.connector.persistence.converters.AccessTokenEntityConverter;
+import org.interledger.connector.persistence.entities.TransactionEntity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.support.ConfigurableConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link AccessTokensRepository}.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {
+  ConnectorPersistenceConfig.class, TransactionsRepositoryTest.TestPersistenceConfig.class
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DataJpaTest
+@AutoConfigureEmbeddedDatabase
+public class TransactionsRepositoryTest {
+
+  public static final PageRequest DEFAULT_PAGE = PageRequest.of(0, 100);
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+  @Autowired
+  private TransactionsRepository transactionsRepository;
+
+  @Autowired
+  private NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Test
+  public void upsertSingleTransaction() {
+    AccountId accountId = AccountId.of(generateUuid());
+    String transactionId = generateUuid();
+
+    final TransactionEntity entity1 = newEntity(accountId, transactionId, 10);
+
+    transactionsRepository.upsertAmounts(entity1);
+
+    final TransactionEntity loadedAccessTokenEntity =
+      transactionsRepository.findByAccountIdAndReferenceId(accountId, transactionId).get();
+
+    assertEqual(loadedAccessTokenEntity, entity1);
+  }
+
+  @Test
+  public void updateStatus() {
+    AccountId accountId = AccountId.of(generateUuid());
+    String transactionId = generateUuid();
+
+    final TransactionEntity entity1 = newEntity(accountId, transactionId, 10);
+
+    transactionsRepository.upsertAmounts(entity1);
+
+    transactionsRepository.updateStatus(accountId, transactionId, "CLOSED_BY_SENDER");
+
+    TransactionEntity transaction1 =
+      transactionsRepository.findByAccountIdAndReferenceId(accountId, transactionId).get();
+    assertThat(transaction1.getStatus()).isEqualTo("CLOSED_BY_SENDER");
+  }
+
+  @Test
+  public void findByAccountIdPagination() {
+    AccountId accountId = AccountId.of(generateUuid());
+    int transactionCount = 125;
+    for (int i = 0; i < transactionCount; i++) {
+      transactionsRepository.upsertAmounts(newEntity(accountId, generateUuid(), 10));
+    }
+
+    List<TransactionEntity> trx1to50 = transactionsRepository.findByAccountIdOrderByCreatedDateDesc(
+      accountId, PageRequest.of(0, 50)
+    );
+
+    assertThat(trx1to50).hasSize(50);
+
+    List<TransactionEntity> trx51To100 = transactionsRepository.findByAccountIdOrderByCreatedDateDesc(
+      accountId, PageRequest.of(1, 50)
+    );
+
+    assertThat(trx51To100).hasSize(50);
+
+    List<TransactionEntity> trx101To125 = transactionsRepository.findByAccountIdOrderByCreatedDateDesc(
+      accountId, PageRequest.of(2, 50)
+    );
+
+    assertThat(trx101To125).hasSize(25);
+
+
+    assertThat(ImmutableSet.builder().addAll(trx1to50).addAll(trx51To100).addAll(trx101To125).build())
+      .hasSize(transactionCount);
+  }
+
+  @Test
+  public void findByAccountIdWithWrongAccountIdReturnsEmpty() {
+    AccountId accountId = AccountId.of(generateUuid());
+    transactionsRepository.upsertAmounts(newEntity(accountId, generateUuid(), 10));
+
+    AccountId wrongAccountId = AccountId.of(generateUuid());
+    assertThat(transactionsRepository.findByAccountIdOrderByCreatedDateDesc(wrongAccountId, DEFAULT_PAGE)).isEmpty();
+  }
+
+  @Test
+  public void findByReferenceIdWithWrongAccountIdReturnsEmpty() {
+    AccountId accountId = AccountId.of(generateUuid());
+    String referenceId = generateUuid();
+    transactionsRepository.upsertAmounts(newEntity(accountId, referenceId, 10));
+
+    AccountId wrongAccountId = AccountId.of(generateUuid());
+    assertThat(transactionsRepository.findByAccountIdAndReferenceId(wrongAccountId, referenceId)).isEmpty();
+  }
+
+  @Test
+  public void upsertMultipleTransactions() throws InterruptedException {
+    AccountId accountId = AccountId.of(generateUuid());
+    String transactionId = generateUuid();
+    String transactionId2 = generateUuid();
+
+    final TransactionEntity entity1 = newEntity(accountId, transactionId, 10);
+
+    transactionsRepository.upsertAmounts(entity1);
+
+    final TransactionEntity loadedAccessTokenEntity =
+      transactionsRepository.findByAccountIdAndReferenceId(accountId, transactionId).get();
+
+    assertEqual(loadedAccessTokenEntity, entity1);
+
+    Thread.sleep(1000); // sleep to make it more predictable to
+
+    final TransactionEntity entity2 = newEntity(accountId, transactionId, 20);
+    transactionsRepository.upsertAmounts(entity2);
+
+    assertThat(transactionsRepository.findByAccountIdOrderByCreatedDateDesc(accountId, DEFAULT_PAGE)).hasSize(1);
+    Optional<TransactionEntity> transaction1 =
+      transactionsRepository.findByAccountIdAndReferenceId(accountId, transactionId);
+
+    assertThat(transaction1).isPresent();
+    assertThat(transaction1.get().getPacketCount()).isEqualTo(2);
+    assertThat(transaction1.get().getAmount()).isEqualTo(BigInteger.valueOf(30));
+
+    transactionsRepository.updateStatus(accountId, transactionId, "CLOSED_BY_SENDER");
+
+    assertThat(transactionsRepository.findByAccountIdOrderByCreatedDateDesc(accountId, DEFAULT_PAGE)).hasSize(1);
+
+    transaction1 = transactionsRepository.findByAccountIdAndReferenceId(accountId, transactionId);
+    assertThat(transaction1.get().getStatus()).isEqualTo("CLOSED_BY_SENDER");
+
+    transactionsRepository.upsertAmounts(newEntity(accountId, transactionId2, 33));
+
+    assertThat(transactionsRepository.findByAccountIdOrderByCreatedDateDesc(accountId, DEFAULT_PAGE)).hasSize(2);
+
+    Optional<TransactionEntity> transaction1Again =
+      transactionsRepository.findByAccountIdAndReferenceId(accountId, transactionId);
+    Optional<TransactionEntity> transaction2 =
+      transactionsRepository.findByAccountIdAndReferenceId(accountId, transactionId2);
+
+    assertEqual(transaction1Again.get(), transaction1.get());
+
+    assertThat(transaction2).isPresent();
+    assertThat(transaction2.get().getAmount()).isEqualTo(BigInteger.valueOf(33));
+    assertThat(transaction2.get().getPacketCount()).isEqualTo(1);
+    assertThat(transaction2.get().getModifiedDate()).isEqualTo(transaction2.get().getCreatedDate());
+  }
+
+  private String generateUuid() {
+    return UUID.randomUUID().toString();
+  }
+
+  private TransactionEntity newEntity(AccountId accountId, String referenceId, long amount) {
+    TransactionEntity entity = new TransactionEntity();
+    entity.setSourceAddress("test.foo.bar");
+    entity.setAccountId(accountId);
+    entity.setPacketCount(1);
+    entity.setReferenceId(referenceId);
+    entity.setAmount(BigInteger.valueOf(amount));
+    entity.setAssetCode("XRP");
+    entity.setAssetScale((short) 9);
+    entity.setDestinationAddress("test." + referenceId);
+    entity.setStatus("PENDING");
+    entity.setType("PAYMENT_RECEIVED");
+    return entity;
+  }
+
+  private void assertEqual(TransactionEntity actual, TransactionEntity expected) {
+    assertThat(actual).isEqualToIgnoringGivenFields(expected, "id", "createdDate", "modifiedDate");
+  }
+
+  @Configuration("application.yml")
+  public static class TestPersistenceConfig {
+
+    ////////////////////////
+    // SpringConverters
+    ////////////////////////
+
+    @Autowired
+    private AccessTokenEntityConverter accessTokensEntityConverter;
+
+    @Bean
+    public ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+
+    @Bean
+    public ConfigurableConversionService conversionService() {
+      ConfigurableConversionService conversionService = new DefaultConversionService();
+      conversionService.addConverter(accessTokensEntityConverter);
+      return conversionService;
+    }
+  }
+}


### PR DESCRIPTION
Persistence for transactions
Implemented using upsert so that as packet fulfillments are generated by the receiving wallet, the amounts and be merged into the stream payment in a single, atomic database call.
Other mutable fields like status and source address that are updated by specific stream frames are implemented as single, atomic SQL updates.