### PR TITLE
revert back to using explicit includes per migration file

### DIFF
--- a/connector-persistence/src/main/resources/db/changelog-master.xml
+++ b/connector-persistence/src/main/resources/db/changelog-master.xml
@@ -15,6 +15,8 @@
     <property name="timestamp" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
 
     <!-- DDL -->
-    <includeAll path="db/changelogs/base"/>
+    <include file="db/changelogs/base/changelog.xml"/>
+    <include file="db/changelogs/base/changelog_00001_access_token.xml"/>
+    <include file="db/changelogs/base/changelog_00002_stream_payments.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
because liquibase includeAll is broken for jars: https://liquibase.jira.com/browse/CORE-3192

Signed-off-by: nhartner <nhartner@gmail.com>